### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: "Bug Report (local)"
+description: "A defect found directly in this repo, not yet tracked in the main movie-finder tracker."
+title: "[BUG] <short description>"
+labels: ["bug"]
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Local Bug Report
+        If this bug is part of a broader finding already tracked in the
+        [main movie-finder repo](https://github.com/aharbii/movie-finder/issues),
+        use the **Linked Task** template instead.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Severity"
+      options:
+        - "critical – data loss / security breach / service down"
+        - "high     – major feature broken, no workaround"
+        - "medium   – feature degraded, workaround exists"
+        - "low      – cosmetic / minor inconvenience"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      placeholder: |
+        **Actual behaviour:**
+        …
+        **Expected behaviour:**
+        …
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: "Steps to reproduce"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Environment"
+      placeholder: |
+        - Python / Node version:
+        - Branch / commit:
+        - Docker / local:
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Relevant logs"
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Open a tracking issue in the main repo first"
+    url: https://github.com/aharbii/movie-finder/issues/new/choose
+    about: All issues should originate in the main movie-finder tracker. Open one there, then link it back here using the Linked Task template.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,49 @@
+name: "Enhancement (local)"
+description: "A feature request or improvement specific to this repo, not yet tracked in the main tracker."
+title: "[FEAT] <short description>"
+labels: ["enhancement"]
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Local Enhancement
+        If this enhancement is part of a finding already tracked in the
+        [main movie-finder repo](https://github.com/aharbii/movie-finder/issues),
+        use the **Linked Task** template instead.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priority"
+      options:
+        - "critical – needed before next release"
+        - "high     – deliver in current sprint"
+        - "medium   – near term"
+        - "low      – backlog"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: "Motivation"
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: "Acceptance criteria"
+      placeholder: |
+        - [ ] …
+        - [ ] Tests pass
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/linked_task.yml
+++ b/.github/ISSUE_TEMPLATE/linked_task.yml
@@ -1,0 +1,77 @@
+name: "Linked Task (from main tracker)"
+description: "Work item linked from an issue in aharbii/movie-finder. Use this for all cross-repo tasks."
+title: "[TASK] <copy title from parent issue>"
+labels: ["task"]
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Linked Task
+        This issue represents the work item for a finding originally tracked in the
+        **[movie-finder main tracker](https://github.com/aharbii/movie-finder/issues)**.
+
+        After creating this issue, go back to the parent issue and paste this URL
+        into the **"Linked submodule issue"** field.
+
+  - type: input
+    id: parent_issue
+    attributes:
+      label: "Parent issue (main tracker)"
+      description: "URL of the originating issue in aharbii/movie-finder"
+      placeholder: "https://github.com/aharbii/movie-finder/issues/<N>"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: "Issue type"
+      options:
+        - "bug           – runtime defect"
+        - "technical-debt – design / code quality"
+        - "security       – vulnerability / hardening"
+        - "enhancement    – new feature / improvement"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Severity / Priority"
+      options:
+        - "critical"
+        - "high"
+        - "medium"
+        - "low"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "Summarise the work to be done in this repo. Copy from the parent issue if unchanged."
+    validations:
+      required: true
+
+  - type: textarea
+    id: file_refs
+    attributes:
+      label: "Relevant files / lines"
+      placeholder: |
+        src/chain/graph.py:192
+        src/app/session/store.py:52–83
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: "Acceptance criteria"
+      placeholder: |
+        - [ ] …
+        - [ ] All tests pass
+        - [ ] PR reviewed and merged
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Adds 4 GitHub issue form templates to `.github/ISSUE_TEMPLATE/`
- `linked_task.yml`: work items cross-linked from the main `movie-finder` tracker
- `bug_report.yml`: local defect reports
- `enhancement.yml`: local feature requests
- `config.yml`: disables blank issues, points contributors to the main tracker

## Why
Part of the project-wide issue tracking setup across all submodule repos.
Parent context: aharbii/movie-finder

## Test plan
- [ ] Navigate to Issues → New Issue on GitHub and verify all 3 templates appear